### PR TITLE
Fix example in docs that uses deprecated code

### DIFF
--- a/doc/build/orm/mapping_styles.rst
+++ b/doc/build/orm/mapping_styles.rst
@@ -571,11 +571,11 @@ object, mapped to a class called ``Address``, then linked to ``User`` via :func:
                 Column('email_address', String(50))
                 )
 
-    mapper(User, user, properties={
+    mapper_registry.map_imperatively(User, user, properties={
         'addresses' : relationship(Address, backref='user', order_by=address.c.id)
     })
 
-    mapper(Address, address)
+    mapper_registry.map_imperatively(Address, address)
 
 When using classical mappings, classes must be provided directly without the benefit
 of the "string lookup" system provided by Declarative.  SQL expressions are typically


### PR DESCRIPTION
### Description
Just a few lines above, it is said that creating a mapping with `mapper()` is deprecated in favor of `mapper_registry.map_imperatively()`. This PR fixes an example in the documentation that still uses the old function.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
